### PR TITLE
fix(#139): break -- ligature runs in inline |...| code

### DIFF
--- a/eolang.dtx
+++ b/eolang.dtx
@@ -991,7 +991,7 @@ $tex =~ s/>>/\\rangle/g;
 $tex =~ s/(?<![\\\{])([)(.])/\\phiTerminal{\1}/g;
 $tex =~ s/(?<![\\\{]),/\\phiTerminal{,}\\;/g;
 $tex =~ s/\|{2,}/|/g;
-$tex =~ s/\|([^\|]+)\|/\\textnormal{\\texttt{\1}}{}/g;
+$tex =~ s/\|([^\|]+)\|/'\\textnormal{\\texttt{' . ($1 =~ s{-(?=-)}{-{}}gr) . '}}{}'/ge;
 $tex =~ s/\{TEXT(\d+)\}/'\\text{' . $texts[$1] . '}';/ge;
 if ($macro eq 'phiq') {
   print '\(' if ($tex ne '');
@@ -1207,7 +1207,7 @@ sub num {
 }
 sub fmt {
   my ($tex) = @_;
-  $tex =~ s/\|([^\|]+)\|/\\textnormal{\\texttt{\1}}/g;
+  $tex =~ s/\|([^\|]+)\|/'\\textnormal{\\texttt{' . ($1 =~ s{-(?=-)}{-{}}gr) . '}}'/ge;
   return $tex;
 }
 sub toem {

--- a/tests/phi-test.pl
+++ b/tests/phi-test.pl
@@ -42,6 +42,8 @@ debug(`cd '$temp' && pdflatex -halt-on-error -shell-escape -interaction=batchmod
 rewrites_phiq($temp, 'a -> b', '\(a \mathbin{\phiTerminal{\mapsto}} b\)');
 rewrites_phiq($temp, 'a -> \textbf{b}', 'a \mathbin{\phiTerminal{\mapsto}} \textbf{b}');
 rewrites_phiq($temp, '|a| -> b', '\textnormal{\texttt{a}}{} \mathbin{\phiTerminal{\mapsto}} b');
+rewrites_phiq($temp, '|--|', '\textnormal{\texttt{-{}-}}{}');
+rewrites_phiq($temp, '|a---b|', '\textnormal{\texttt{a-{}-{}-b}}{}');
 rewrites_phiq($temp, '[\ccc]', '[\ccc]');
 rewrites_phiq($temp, '\char 44{}', '\(\char 44{}\)');
 rewrites_phiq($temp, '\char44{}', '\(\char44{}\)');


### PR DESCRIPTION
Closes #139.

## Problem

The `|...|` inline-code rewrite in `eolang.dtx` emitted a bare `\texttt{...}`. A typewriter font that ligates consecutive hyphens collapses `--` into a single en-dash. Inconsolata (the default monospace in `acmart`) does exactly this, so `$|--|$` rendered as one dash. The bug stayed hidden under the `article` class because its Computer Modern `cmtt` has no such ligature.

## Fix

Break ligature-forming hyphen runs inside the substituted content by inserting `{}` between adjacent hyphens (`s{-(?=-)}{-{}}gr`). This makes inline code render literally regardless of the typewriter font and works for runs of any length (`--` → `-{}-`, `---` → `-{}-{}-`), while single hyphens and other characters are untouched.

Applied to both rewriters:
- line ~994 (`\phiq` / phi rewriter)
- line ~1210 (`sodg` rewriter)

## Tests

Added two cases to `tests/phi-test.pl`:
- `|--|` → `\textnormal{\texttt{-{}-}}{}`
- `|a---b|` → `\textnormal{\texttt{a-{}-{}-b}}{}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wd9vEQ15jijpwq35catpbo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wd9vEQ15jijpwq35catpbo)_