### PR TITLE
fix(#141): activate dollar sign at load time

### DIFF
--- a/eolang.dtx
+++ b/eolang.dtx
@@ -1156,7 +1156,7 @@ print '\endinput';
 
 % \begin{macro}{nodollar}
 % \changes{0.7.0}{2022/11/18}{Now it is possible to use dollar sign instead of the \texttt{\char`\\phiq} command.}
-% \changes{0.23.1}{2026/07/01}{The dollar sign is made active at load time, so that \texttt{\$...\$} captured inside preamble-defined macros is also converted to \texttt{\char`\\phiq}.}
+% \changes{0.23.1}{2026/07/01}{The dollar sign is made active at the end of the package (\texttt{\char`\\AtEndOfPackage}), so that \texttt{\$...\$} captured inside preamble-defined macros is also converted to \texttt{\char`\\phiq}.}
 % Then, we redefine dollar sign:
 %    \begin{macrocode}
 \ifdefined\eolang@nodollar\else
@@ -1164,7 +1164,7 @@ print '\endinput';
   \catcode`\$=\active
   \protected\gdef$#1${\phiq{#1}}
   \endgroup
-  \catcode`\$=\active
+  \AtEndOfPackage{\catcode`\$=\active}%
   \AtBeginDocument{\catcode`\$=\active}
 \fi
 %    \end{macrocode}

--- a/eolang.dtx
+++ b/eolang.dtx
@@ -1156,6 +1156,7 @@ print '\endinput';
 
 % \begin{macro}{nodollar}
 % \changes{0.7.0}{2022/11/18}{Now it is possible to use dollar sign instead of the \texttt{\char`\\phiq} command.}
+% \changes{0.23.1}{2026/07/01}{The dollar sign is made active at load time, so that \texttt{\$...\$} captured inside preamble-defined macros is also converted to \texttt{\char`\\phiq}.}
 % Then, we redefine dollar sign:
 %    \begin{macrocode}
 \ifdefined\eolang@nodollar\else
@@ -1163,6 +1164,7 @@ print '\endinput';
   \catcode`\$=\active
   \protected\gdef$#1${\phiq{#1}}
   \endgroup
+  \catcode`\$=\active
   \AtBeginDocument{\catcode`\$=\active}
 \fi
 %    \end{macrocode}


### PR DESCRIPTION
Closes #141.

## Problem

The active-`$` → `\phiq` conversion did not fire when `$...$` sat inside a macro defined in the preamble. The active-`$` meaning was set up inside a group (`eolang.dtx:1162-1166`), but the catcode was only switched on via `\AtBeginDocument{\catcode`\$=\active}`. Any `\newcommand` issued between `\usepackage{eolang}` and `\begin{document}` therefore tokenized its `$` at catcode 3 (math shift), so those frozen dollars never reached `\phiq`.

## Fix

Run `\catcode`\$=\active` immediately after the `\gdef` (outside the group), in addition to the existing `\AtBeginDocument` hook. This makes `$` active at load time, so preamble-defined macros capture the active `$` and their `$...$` is converted to `\phiq` just like `$...$` typed in the document body.

The `\AtBeginDocument` hook is retained so the catcode is restored in case a package loaded afterwards resets it.

## Notes

No regression test (`.lvt`/`.tlg`) was added: the `l3build` reference logs are keyed to exact content hashes and line numbers and require the full TeX + `-shell-escape` toolchain to regenerate, which is not available in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pp7dDGRDn3YN15C9KSdKBz)_